### PR TITLE
Support artists with genres in CLI

### DIFF
--- a/cli/src/models/artists.rs
+++ b/cli/src/models/artists.rs
@@ -14,6 +14,9 @@ pub struct Artist {
     /// The total number of followers that the artist has
     followers: i32,
 
+    /// The genres the artist is known for
+    genres: Vec<String>,
+
     /// The Spotify ID of the artist
     id: String,
 }
@@ -25,6 +28,7 @@ impl Content for Artist {
             &self.name,
             &self.popularity,
             &self.followers,
+            &self.genres.join(", "),
             &self.id
         )
     }

--- a/cli/src/models/collections.rs
+++ b/cli/src/models/collections.rs
@@ -18,7 +18,14 @@ pub struct ArtistCollection {
 impl ContentCollection for ArtistCollection {
     fn display(&self) {
         let mut table = Table::new();
-        table.add_row(row!("Rank", "Artist", "Popularity", "Followers", "ID"));
+        table.add_row(row!(
+            "Rank",
+            "Artist",
+            "Popularity",
+            "Followers",
+            "Genres",
+            "ID"
+        ));
         self.items
             .iter()
             .enumerate()


### PR DESCRIPTION
# Description

This PR adds support for displaying genres retrieved from the artists endpoint

## Checklist

- [X] Title contains a short meaningful description of the change
- [X] Message contains a link to a related issue if one exists
- [ ] Relevant documentation has been updated
- [ ] Tests have been updated/created
- [X] Changes have been tested in a local or dev environment
